### PR TITLE
Fix insertion of spurious U+FEFF in UTF-8-SIG files

### DIFF
--- a/rpl/__init__.py
+++ b/rpl/__init__.py
@@ -463,6 +463,11 @@ def main(  # pylint: disable=dangerous-default-value
                 if args.verbose:
                     warn(f"Could not guess encoding; using locale default '{encoding}'")
 
+            # Disable special handling of BOM in UTF-8 files, otherwise it would be
+            # inserted after each replacement
+            if encoding.upper() == "UTF-8-SIG":
+                encoding = "UTF-8"
+
         # Do the actual work now
         try:
             num_matches = replace(f, o, old_regex, new_str, encoding, args.ignore_case)

--- a/tests/test_rpl.py
+++ b/tests/test_rpl.py
@@ -64,6 +64,14 @@ def test_utf_8(datafiles: Path) -> None:
         assert re.search("amèt", f.read())
 
 
+@pytest.mark.datafiles(FIXTURE_DIR / "utf-8-sig.txt")
+def test_utf_8_sig(datafiles: Path) -> None:
+    test_file = str(datafiles / "utf-8-sig.txt")
+    main(["BOM mark", "BOM", test_file])
+    with open(test_file, encoding="utf-8") as f:
+        assert not re.search("\uFEFF at", f.read())
+
+
 def test_version(capsys: CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as e:
         main(["--version"])

--- a/tests/utf-8-sig.txt
+++ b/tests/utf-8-sig.txt
@@ -1,0 +1,1 @@
+﻿This UTF-8 file has a BOM mark at its beginning.


### PR DESCRIPTION
Don't insert `U+FEFF` characters after each replacement if the file is UTF-8 with a Byte Order Mark. Using BOM doesn't make much sense in UTF-8 files, yet such files exist and rpl would previously corrupt them by inserting the mark after each replacement. Because the inserted `U+FEFF ZERO WIDTH NO-BREAK SPACE` is an invisible character, this is often easy to
miss, potentially (as was the case for me) causing mysterious errors.

This was caused by the way rpl encodes the output in pieces. Python's UTF-8-SIG codec [is stateful and only outputs BOM at the beginning](https://docs.python.org/3.12/library/codecs.html#module-encodings.utf_8_sig), but [the way strings are encoded in rpl](https://github.com/rrthomas/rpl/blob/e3539e6243a30009e2c6052b6259d06ed598bb66/rpl/__init__.py#L159), "beginning" is after every match as well.

There are multiple ways to fix it:

1. Use stateful encoder.
2. Do the encoding all at once, instead of chunk-wise.
3. Do the minimal change possible, treat UTF-8-SIG as regular UTF-8.

This PR implements the 3rd option as both the smallest change and the safest / least error-prone. Note that doing this is safe because UTF-8 with BOM is valid UTF-8 too. (I'd even argue it is *good* to normalize to UTF-8 because it allows rpl to operate on this character and e.g. remove it.)

To illustrate the bug, this is how this file (shown in ViM as one of the few editors that will visualize it):
<img width="907" alt="Screenshot 2024-03-11 at 17 15 43" src="https://github.com/rrthomas/rpl/assets/145881/a9e9f847-eab5-41a3-a438-15e67a6c6cf0">
...changes after running the innocuous `rpl 0.22.4 0.22.5 packages.config` command:
<img width="907" alt="Screenshot 2024-03-11 at 17 16 06" src="https://github.com/rrthomas/rpl/assets/145881/8466afaf-0669-4e62-b5d5-67aebae16cfb">


