### PR TITLE
Catch exception for missing os.chown-module on Windows

### DIFF
--- a/rpl/__init__.py
+++ b/rpl/__init__.py
@@ -426,7 +426,7 @@ def main(argv: list[str] = sys.argv[1:]) -> None:
                 try:
                     os.chown(tmp_path, perms.st_uid, perms.st_gid)
                     os.chmod(tmp_path, perms.st_mode)
-                except OSError as e:
+                except (OSError, AttributeError) as e:
                     warn(f"Unable to set attributes of {filename}; error: {e}")
                     if args.force:
                         warn("New file attributes may not match!")


### PR DESCRIPTION
Hello, great work on this project. I particularly enjoy the CLI for python!
While no issues on unix, file permissions are not supported on Windows machines.

This results in an uncaught exception. An [OSError is caught](https://github.com/rrthomas/rpl/blob/f57c824d711d25c6276d58c0088e0ceae8a4a61c/rpl/__init__.py#L426-L430), but Windows raises a AttributeError, due to the [module `chown` not existing on Windows](https://docs.python.org/3.14/library/os.html#os.chown) versions of the `os` standard library.

This PR is very minimal to address this issue and prevent the CLI crashing on windows: Add `AttributeError` to that except block.

All test pass with tox, as well as the build (run with make). Additionally, I locally tested on MacOS and, of course, on Windows.

With the change, the CLI works smoothly on Windows when passing the `-f` argument.

I'd be delighted if you could pull the changes and release a new version in the PyPI!